### PR TITLE
Zone Approach

### DIFF
--- a/app/prependers/models/spree/zone/for_address.rb
+++ b/app/prependers/models/spree/zone/for_address.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Spree::Zone::ForAddress
+  def self.prepended(base)
+    base.scope :with_member_ids, ->(state_ids, country_ids, zipcode) do
+      if state_ids.blank? && country_ids.blank? && zipcode.blank?
+        none
+      else
+        if country_ids==233
+          zipcode = zipcode.split('-').first
+        end
+        spree_zone_members_table = Spree::ZoneMember.arel_table
+        matching_state =
+          spree_zone_members_table[:zoneable_type].eq("Spree::State").
+            and(spree_zone_members_table[:zoneable_id].in(state_ids))
+        matching_country =
+          spree_zone_members_table[:zoneable_type].eq("Spree::Country").
+            and(spree_zone_members_table[:zoneable_id].in(country_ids))
+        spree_zones_table = Spree::Zone.arel_table
+        matching_zipcode = spree_zones_table[:zipcodes].matches("%#{zipcode}%")
+        zipcodes = left_joins(:zone_members).where(matching_zipcode).distinct
+        return zipcodes unless zipcodes.empty?
+
+        left_joins(:zone_members).where(matching_zipcode.or(matching_state.or(matching_country))).distinct
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Apply Zip Code Zones tax rate by overriding Spree::Zone

Use prependers to override the logic in Spree::Zone that returns a list of zones that match a particular address to return if it finds any zip code zones. If not, then proceed to return the rest of the zones.